### PR TITLE
GMI_clw_ObsError_assignment

### DIFF
--- a/test/testinput/hyb-3dvar_geos.yaml
+++ b/test/testinput/hyb-3dvar_geos.yaml
@@ -807,12 +807,6 @@ cost function:
         channels: 10,12,13
       minvalue: 70.0
       maxvalue: 320.0
-    - filter: Background Check
-      apply at iterations: 0, 1
-      filter variables:
-      - name: brightness_temperature
-        channels: 5,6,7,10,12,13
-      threshold: 2.0
     - filter: Domain Check
       filter variables:
       - name: brightness_temperature
@@ -849,6 +843,76 @@ cost function:
           name: longitude@MetaData
         minvalue: 25.0
         maxvalue: 40.0
+    #  CLW Retrieval Check from ObsValue
+    - filter: Bounds Check
+      filter variables:
+      - name: brightness_temperature
+        channels: 5,6,7,10,12,13
+      test variables:
+      - name: CLWRetMW@ObsFunction
+        options:
+          clwret_ch37v: 6
+          clwret_ch37h: 7
+          clwret_types: [ObsValue]
+      maxvalue: 999.0
+      action:
+        name: reject
+    #  CLW Retrieval Check from HofX
+    - filter: Bounds Check
+      filter variables:
+      - name: brightness_temperature
+        channels: 5,6,7,10,12,13
+      test variables:
+      - name: CLWRetMW@ObsFunction
+        options:
+          clwret_ch37v: 6
+          clwret_ch37h: 7
+          clwret_types: [HofX]
+      maxvalue: 999.0
+      action:
+        name: reject
+    # Assign observational error in all-sky DA.
+    - filter: BlackList
+      filter variables:
+      - name: brightness_temperature
+        channels: 5,6,7,10,12,13
+      action:
+        name: assign error
+        error function:
+          name: ObsErrorModelRamp@ObsFunction
+          channels: 5,6,7,10,12,13
+          options:
+            channels: 5,6,7,10,12,13
+            xvar:
+              name: CLWRetSymmetricMW@ObsFunction
+              options:
+                clwret_ch37v: 6
+                clwret_ch37h: 7
+                clwret_types: [ObsValue, HofX]
+            x0:    [ 0.050,
+                     0.050,  0.050,
+                     0.050,  0.050,  0.050]
+            x1:    [ 0.200,
+                     0.200,  0.200,
+                     0.200,  0.300,  0.300]
+            x2:    [ 0.500,
+                     0.500,  0.500,
+                     0.500,  0.500,  0.500]
+            err0:  [ 4.000,
+                     3.800,300.000,
+                     5.000,  2.500,  3.000]
+            err1:  [11.000,
+                    13.300, 23.000, 
+                    20.000,  8.000, 13.000]
+            err2:  [35.000,
+                    25.300,500.000,
+                    50.000, 30.000, 40.000]
+    - filter: Background Check
+      apply at iterations: 0, 1
+      filter variables:
+      - name: brightness_temperature
+        channels: 5,6,7,10,12,13
+      threshold: 2.0
   - obs space:
       name: AIRS-AQUA
       obsdatain:

--- a/test/testoutput/hyb-3dvar_geos.ref
+++ b/test/testoutput/hyb-3dvar_geos.ref
@@ -15,14 +15,14 @@ Test     : CostJo   : Nonlinear Jo(SNDRD2-GOES15) = 608.368, nobs = 1017, Jo/n =
 Test     : CostJo   : Nonlinear Jo(SNDRD3-GOES15) = 630.404, nobs = 1006, Jo/n = 0.626644, err = 1.53014
 Test     : CostJo   : Nonlinear Jo(SNDRD4-GOES15) = 605.757, nobs = 996, Jo/n = 0.60819, err = 1.53701
 Test     : CostJo   : Nonlinear Jo(ATMS-NPP) = 1116.96, nobs = 1578, Jo/n = 0.707835, err = 2.11358
-Test     : CostJo   : Nonlinear Jo(GMI-GPM) = 3.35353, nobs = 11, Jo/n = 0.304866, err = 127.964
+Test     : CostJo   : Nonlinear Jo(GMI-GPM) = 1.71379, nobs = 12, Jo/n = 0.142816, err = 73.4756
 Test     : CostJo   : Nonlinear Jo(AIRS-AQUA) = 5679.37, nobs = 9128, Jo/n = 0.622192, err = 1.32383
 Test     : CostJo   : Nonlinear Jo(IASI-METOPA) = 6561.08, nobs = 12302, Jo/n = 0.533334, err = 1.19964
 Test     : CostJo   : Nonlinear Jo(IASI-METOPB) = 7168.93, nobs = 12236, Jo/n = 0.585889, err = 1.19724
 Test     : CostJo   : Nonlinear Jo(CRIS-NPP) = 2055.16, nobs = 2224, Jo/n = 0.924082, err = 0.84566
 Test     : CostJo   : Nonlinear Jo(SfcObs) = 50.627, nobs = 53, Jo/n = 0.955226, err = 143.514
-Test     : CostFunction: Nonlinear J = 34208.9
-Test     : DRIPCGMinimizer: reduction in residual norm = 0.252471
+Test     : CostFunction: Nonlinear J = 34207.2
+Test     : DRIPCGMinimizer: reduction in residual norm = 0.252532
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :  --------------------------------------------------------------------------------
 Test     :  State print | number of fields = 21 | cube sphere face size: C12
@@ -48,31 +48,31 @@ Test     :    soilm         : Min = +2.728177e-02, Max = +1.000000e+00, RMS = +9
 Test     :    u10m          : Min = -1.541011e+01, Max = +2.004475e+01, RMS = +5.677292e+00
 Test     :    v10m          : Min = -1.646713e+01, Max = +1.457106e+01, RMS = +4.830783e+00
 Test     :  --------------------------------------------------------------------------------
-Test     : CostJb   : Nonlinear Jb = 5.93662e-05
+Test     : CostJb   : Nonlinear Jb = 5.94235e-05
 Test     : CostJo   : Nonlinear Jo(Aircraft) = 2947.35, nobs = 1450, Jo/n = 2.03266, err = 2.66942
 Test     : CostJo   : Nonlinear Jo(Radiosonde) = 1989.05, nobs = 1119, Jo/n = 1.77752, err = 2.0597
-Test     : CostJo   : Nonlinear Jo(GnssroBndNBAM) = 362.982, nobs = 147, Jo/n = 2.46926, err = 0.000272239
-Test     : CostJo   : Nonlinear Jo(AMSUA-METOP-A) = 631.289, nobs = 635, Jo/n = 0.994156, err = 1.28101
+Test     : CostJo   : Nonlinear Jo(GnssroBndNBAM) = 362.994, nobs = 147, Jo/n = 2.46935, err = 0.000272239
+Test     : CostJo   : Nonlinear Jo(AMSUA-METOP-A) = 631.287, nobs = 635, Jo/n = 0.994152, err = 1.28101
 Test     : CostJo   : Nonlinear Jo(AMSUA-METOP-B) = 446.576, nobs = 601, Jo/n = 0.743054, err = 1.30716
-Test     : CostJo   : Nonlinear Jo(AMSUA-NOAA15) = 358.44, nobs = 724, Jo/n = 0.495082, err = 0.737924
+Test     : CostJo   : Nonlinear Jo(AMSUA-NOAA15) = 358.439, nobs = 724, Jo/n = 0.495082, err = 0.737924
 Test     : CostJo   : Nonlinear Jo(AMSUA-NOAA18) = 534.976, nobs = 458, Jo/n = 1.16807, err = 1.48775
-Test     : CostJo   : Nonlinear Jo(AMSUA-NOAA19) = 702.206, nobs = 650, Jo/n = 1.08032, err = 1.26774
-Test     : CostJo   : Nonlinear Jo(MHS-NOAA18) = 261.285, nobs = 416, Jo/n = 0.628088, err = 2.30176
-Test     : CostJo   : Nonlinear Jo(MHS-METOP-A) = 301.137, nobs = 402, Jo/n = 0.749097, err = 2.29942
-Test     : CostJo   : Nonlinear Jo(MHS-METOP-B) = 292.513, nobs = 401, Jo/n = 0.729459, err = 2.30133
-Test     : CostJo   : Nonlinear Jo(SNDRD1-GOES15) = 539.332, nobs = 1024, Jo/n = 0.526691, err = 1.5136
-Test     : CostJo   : Nonlinear Jo(SNDRD2-GOES15) = 527.382, nobs = 1017, Jo/n = 0.518566, err = 1.52933
-Test     : CostJo   : Nonlinear Jo(SNDRD3-GOES15) = 533.929, nobs = 1006, Jo/n = 0.530744, err = 1.53014
-Test     : CostJo   : Nonlinear Jo(SNDRD4-GOES15) = 525.842, nobs = 996, Jo/n = 0.527954, err = 1.53701
-Test     : CostJo   : Nonlinear Jo(ATMS-NPP) = 1018.01, nobs = 1578, Jo/n = 0.645127, err = 2.11358
-Test     : CostJo   : Nonlinear Jo(GMI-GPM) = 4.38759, nobs = 11, Jo/n = 0.398872, err = 127.964
-Test     : CostJo   : Nonlinear Jo(AIRS-AQUA) = 5367.5, nobs = 9128, Jo/n = 0.588025, err = 1.32383
-Test     : CostJo   : Nonlinear Jo(IASI-METOPA) = 6409.01, nobs = 12302, Jo/n = 0.520973, err = 1.19964
-Test     : CostJo   : Nonlinear Jo(IASI-METOPB) = 6983.93, nobs = 12236, Jo/n = 0.570769, err = 1.19724
-Test     : CostJo   : Nonlinear Jo(CRIS-NPP) = 1954.88, nobs = 2223, Jo/n = 0.879386, err = 0.845584
+Test     : CostJo   : Nonlinear Jo(AMSUA-NOAA19) = 702.205, nobs = 650, Jo/n = 1.08031, err = 1.26774
+Test     : CostJo   : Nonlinear Jo(MHS-NOAA18) = 261.308, nobs = 416, Jo/n = 0.628143, err = 2.30176
+Test     : CostJo   : Nonlinear Jo(MHS-METOP-A) = 301.125, nobs = 402, Jo/n = 0.749068, err = 2.29942
+Test     : CostJo   : Nonlinear Jo(MHS-METOP-B) = 292.519, nobs = 401, Jo/n = 0.729473, err = 2.30133
+Test     : CostJo   : Nonlinear Jo(SNDRD1-GOES15) = 539.335, nobs = 1024, Jo/n = 0.526694, err = 1.5136
+Test     : CostJo   : Nonlinear Jo(SNDRD2-GOES15) = 527.388, nobs = 1017, Jo/n = 0.518572, err = 1.52933
+Test     : CostJo   : Nonlinear Jo(SNDRD3-GOES15) = 533.932, nobs = 1006, Jo/n = 0.530748, err = 1.53014
+Test     : CostJo   : Nonlinear Jo(SNDRD4-GOES15) = 525.845, nobs = 996, Jo/n = 0.527957, err = 1.53701
+Test     : CostJo   : Nonlinear Jo(ATMS-NPP) = 1017.98, nobs = 1578, Jo/n = 0.645108, err = 2.11358
+Test     : CostJo   : Nonlinear Jo(GMI-GPM) = 2.10191, nobs = 12, Jo/n = 0.175159, err = 73.4756
+Test     : CostJo   : Nonlinear Jo(AIRS-AQUA) = 5367.49, nobs = 9128, Jo/n = 0.588025, err = 1.32383
+Test     : CostJo   : Nonlinear Jo(IASI-METOPA) = 6408.99, nobs = 12302, Jo/n = 0.520971, err = 1.19964
+Test     : CostJo   : Nonlinear Jo(IASI-METOPB) = 6983.91, nobs = 12236, Jo/n = 0.570767, err = 1.19724
+Test     : CostJo   : Nonlinear Jo(CRIS-NPP) = 1954.86, nobs = 2223, Jo/n = 0.879379, err = 0.845584
 Test     : CostJo   : Nonlinear Jo(SfcObs) = 50.627, nobs = 53, Jo/n = 0.955226, err = 143.514
-Test     : CostFunction: Nonlinear J = 32742.6
-Test     : DRIPCGMinimizer: reduction in residual norm = 0.546518
+Test     : CostFunction: Nonlinear J = 32740.3
+Test     : DRIPCGMinimizer: reduction in residual norm = 0.546514
 Test     : CostFunction::addIncrement: Analysis: 
 Test     :  --------------------------------------------------------------------------------
 Test     :  State print | number of fields = 21 | cube sphere face size: C12
@@ -98,27 +98,27 @@ Test     :    soilm         : Min = +2.728177e-02, Max = +1.000000e+00, RMS = +9
 Test     :    u10m          : Min = -1.541011e+01, Max = +2.004475e+01, RMS = +5.677292e+00
 Test     :    v10m          : Min = -1.646713e+01, Max = +1.457106e+01, RMS = +4.830783e+00
 Test     :  --------------------------------------------------------------------------------
-Test     : CostJb   : Nonlinear Jb = 6.52482e-05
+Test     : CostJb   : Nonlinear Jb = 6.53112e-05
 Test     : CostJo   : Nonlinear Jo(Aircraft) = 2947.35, nobs = 1450, Jo/n = 2.03266, err = 2.66942
 Test     : CostJo   : Nonlinear Jo(Radiosonde) = 1989.05, nobs = 1119, Jo/n = 1.77752, err = 2.0597
-Test     : CostJo   : Nonlinear Jo(GnssroBndNBAM) = 332.299, nobs = 147, Jo/n = 2.26053, err = 0.000272239
-Test     : CostJo   : Nonlinear Jo(AMSUA-METOP-A) = 631.317, nobs = 635, Jo/n = 0.9942, err = 1.28101
+Test     : CostJo   : Nonlinear Jo(GnssroBndNBAM) = 332.304, nobs = 147, Jo/n = 2.26057, err = 0.000272239
+Test     : CostJo   : Nonlinear Jo(AMSUA-METOP-A) = 631.314, nobs = 635, Jo/n = 0.994195, err = 1.28101
 Test     : CostJo   : Nonlinear Jo(AMSUA-METOP-B) = 446.579, nobs = 601, Jo/n = 0.74306, err = 1.30716
 Test     : CostJo   : Nonlinear Jo(AMSUA-NOAA15) = 358.44, nobs = 724, Jo/n = 0.495082, err = 0.737924
 Test     : CostJo   : Nonlinear Jo(AMSUA-NOAA18) = 534.992, nobs = 458, Jo/n = 1.16811, err = 1.48775
-Test     : CostJo   : Nonlinear Jo(AMSUA-NOAA19) = 702.246, nobs = 650, Jo/n = 1.08038, err = 1.26774
-Test     : CostJo   : Nonlinear Jo(MHS-NOAA18) = 250.253, nobs = 416, Jo/n = 0.601569, err = 2.30176
-Test     : CostJo   : Nonlinear Jo(MHS-METOP-A) = 287.693, nobs = 402, Jo/n = 0.715655, err = 2.29942
-Test     : CostJo   : Nonlinear Jo(MHS-METOP-B) = 277.704, nobs = 401, Jo/n = 0.692528, err = 2.30133
-Test     : CostJo   : Nonlinear Jo(SNDRD1-GOES15) = 516.752, nobs = 1024, Jo/n = 0.504641, err = 1.5136
-Test     : CostJo   : Nonlinear Jo(SNDRD2-GOES15) = 504.008, nobs = 1017, Jo/n = 0.495583, err = 1.52933
-Test     : CostJo   : Nonlinear Jo(SNDRD3-GOES15) = 509.424, nobs = 1006, Jo/n = 0.506385, err = 1.53014
-Test     : CostJo   : Nonlinear Jo(SNDRD4-GOES15) = 507.622, nobs = 996, Jo/n = 0.50966, err = 1.53701
-Test     : CostJo   : Nonlinear Jo(ATMS-NPP) = 1012.22, nobs = 1578, Jo/n = 0.641455, err = 2.11358
-Test     : CostJo   : Nonlinear Jo(GMI-GPM) = 4.31986, nobs = 11, Jo/n = 0.392715, err = 127.964
-Test     : CostJo   : Nonlinear Jo(AIRS-AQUA) = 5313.35, nobs = 9128, Jo/n = 0.582093, err = 1.32383
-Test     : CostJo   : Nonlinear Jo(IASI-METOPA) = 6404.96, nobs = 12302, Jo/n = 0.520643, err = 1.19964
-Test     : CostJo   : Nonlinear Jo(IASI-METOPB) = 6981.97, nobs = 12236, Jo/n = 0.570609, err = 1.19724
-Test     : CostJo   : Nonlinear Jo(CRIS-NPP) = 1951.48, nobs = 2223, Jo/n = 0.877861, err = 0.845584
+Test     : CostJo   : Nonlinear Jo(AMSUA-NOAA19) = 702.244, nobs = 650, Jo/n = 1.08038, err = 1.26774
+Test     : CostJo   : Nonlinear Jo(MHS-NOAA18) = 250.27, nobs = 416, Jo/n = 0.601611, err = 2.30176
+Test     : CostJo   : Nonlinear Jo(MHS-METOP-A) = 287.656, nobs = 402, Jo/n = 0.715562, err = 2.29942
+Test     : CostJo   : Nonlinear Jo(MHS-METOP-B) = 277.682, nobs = 401, Jo/n = 0.692475, err = 2.30133
+Test     : CostJo   : Nonlinear Jo(SNDRD1-GOES15) = 516.752, nobs = 1024, Jo/n = 0.50464, err = 1.5136
+Test     : CostJo   : Nonlinear Jo(SNDRD2-GOES15) = 504.009, nobs = 1017, Jo/n = 0.495584, err = 1.52933
+Test     : CostJo   : Nonlinear Jo(SNDRD3-GOES15) = 509.423, nobs = 1006, Jo/n = 0.506385, err = 1.53014
+Test     : CostJo   : Nonlinear Jo(SNDRD4-GOES15) = 507.621, nobs = 996, Jo/n = 0.50966, err = 1.53701
+Test     : CostJo   : Nonlinear Jo(ATMS-NPP) = 1012.17, nobs = 1578, Jo/n = 0.641425, err = 2.11358
+Test     : CostJo   : Nonlinear Jo(GMI-GPM) = 2.08191, nobs = 12, Jo/n = 0.173493, err = 73.4756
+Test     : CostJo   : Nonlinear Jo(AIRS-AQUA) = 5313.32, nobs = 9128, Jo/n = 0.58209, err = 1.32383
+Test     : CostJo   : Nonlinear Jo(IASI-METOPA) = 6404.94, nobs = 12302, Jo/n = 0.520642, err = 1.19964
+Test     : CostJo   : Nonlinear Jo(IASI-METOPB) = 6981.95, nobs = 12236, Jo/n = 0.570607, err = 1.19724
+Test     : CostJo   : Nonlinear Jo(CRIS-NPP) = 1951.47, nobs = 2223, Jo/n = 0.877854, err = 0.845584
 Test     : CostJo   : Nonlinear Jo(SfcObs) = 50.627, nobs = 53, Jo/n = 0.955227, err = 143.514
-Test     : CostFunction: Nonlinear J = 32514.6
+Test     : CostFunction: Nonlinear J = 32512.2


### PR DESCRIPTION
Added cloud filter and observational error assignment for GMI all-sky assimilation in hyb-3dvar_geos.yaml.

## Dependencies
Waiting on the following PRs:
https://github.com/JCSDA/ufo/pull/24
https://github.com/JCSDA/ufo/pull/28