### PR TITLE
Turn off convert state test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -804,10 +804,6 @@ fv3jedi_add_test( NAME    convertstate_gfs
                   EXE     fv3jedi_convertstate.x
                   TOL     1.0e-3 0)
 
-#fv3jedi_add_test( NAME    convertstate_gfs_c2ll
-#                  EXE     fv3jedi_convertstate.x
-#                  TOL     1.0e-4 0 )
-
 fv3jedi_add_test( NAME    convertstate_geos
                   EXE     fv3jedi_convertstate.x )
 


### PR DESCRIPTION
## Description

Turn off the convertstate_gfs_c2ll until it can be properly debugged.