### PR TITLE
Turn off more large tests

### DIFF
--- a/CI/buildspec_clang.yml
+++ b/CI/buildspec_clang.yml
@@ -127,7 +127,7 @@ phases:
       - echo $BUILD_STATUS
 
       - cd /build_container
-      - ecbuild -DSKIP_LARGE_TESTS=ON -DBUNDLE_SKIP_GEOS-AERO=OFF -DBUNDLE_SKIP_ROPP-UFO=OFF /jcsda/fv3-bundle/
+      - ecbuild -DBUNDLE_SKIP_GEOS-AERO=OFF -DBUNDLE_SKIP_ROPP-UFO=OFF /jcsda/fv3-bundle/
       - cd fv3-jedi
       - make -j8
 

--- a/CI/buildspec_gnu.yml
+++ b/CI/buildspec_gnu.yml
@@ -20,7 +20,7 @@ phases:
       - echo $CODEBUILD_WEBHOOK_EVENT
       - echo $CODEBUILD_WEBHOOK_TRIGGER
       - echo $CODEBUILD_WEBHOOK_BASE_REF
-   
+
       # Codebuild only runs on PUSH events if HEAD_REF
       # is refs/heads/develop (merge to develop). In this
       # case CODEBUILD_GIT_BRANCH="develop"
@@ -135,7 +135,7 @@ phases:
 
       #gsw
       - ./clone.sh $GIT_USER $GIT_PASS jcsda-internal/GSW-Fortran $CODEBUILD_GIT_BRANCH gsw /jcsda/fv3-bundle develop
- 
+
       # move CMakeLists.txt
       - cp CMakeLists.txt /jcsda/fv3-bundle
 
@@ -157,7 +157,7 @@ phases:
         && echo $CXX
         && echo $FC
         && CC=mpicc CXX=mpicxx FC=mpifort
-        && cmake -DCMAKE_MODULE_PATH=/usr/local/share/ecbuild/cmake/ -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_GPROF=ON -DBUNDLE_SKIP_GEOS-AERO=OFF -DBUNDLE_SKIP_ROPP-UFO=OFF -DTEST_TIME_REF_FV3=CTestCostData.txt.awsgnu.test /jcsda/fv3-bundle
+        && cmake -DCMAKE_MODULE_PATH=/usr/local/share/ecbuild/cmake/ -DSKIP_LARGE_TESTS=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_GPROF=ON -DBUNDLE_SKIP_GEOS-AERO=OFF -DBUNDLE_SKIP_ROPP-UFO=OFF -DTEST_TIME_REF_FV3=CTestCostData.txt.awsgnu.test /jcsda/fv3-bundle
         && cd fv3-jedi
         && make -j8"
 

--- a/CI/buildspec_intel.yml
+++ b/CI/buildspec_intel.yml
@@ -88,7 +88,7 @@ phases:
 
       #  Set crtm branch name
       - export CRTM_JEDI_BRANCH="v2.3-jedi"
- 
+
       - if [ "$CODEBUILD_GIT_BRANCH" = "develop" ];
         then export CODEBUILD_GIT_BRANCH_FORK="release-stable";
         export CODEBUILD_GIT_BRANCH_CRTM=${CRTM_JEDI_BRANCH};
@@ -182,7 +182,7 @@ phases:
         && . /opt/intel/compilers_and_libraries/linux/bin/compilervars.sh
         && cd /build_container
         && ls
-        && ecbuild /jcsda/fv3-bundle/ -DBUNDLE_SKIP_GEOS-AERO=OFF -DBUNDLE_SKIP_ROPP-UFO=OFF -DTEST_TIME_REF_FV3=CTestCostData.txt.awsintel.test
+        && ecbuild /jcsda/fv3-bundle/ -DSKIP_LARGE_TESTS=OFF -DBUNDLE_SKIP_GEOS-AERO=OFF -DBUNDLE_SKIP_ROPP-UFO=OFF -DTEST_TIME_REF_FV3=CTestCostData.txt.awsintel.test
         && cd fv3-jedi
         && make -j8"
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 # Option not to run with large tests
 # ----------------------------------
-option(SKIP_LARGE_TESTS "Skip tests with more than 6 processors" OFF)
+option(SKIP_LARGE_TESTS "Skip tests with more than 6 processors" ON)
 
 # Create the Data/ directory
 # --------------------------
@@ -1021,10 +1021,12 @@ fv3jedi_add_test( NAME         hyb-fgat_gfs_aero
 
 # 4DEnVar
 # -------
-fv3jedi_add_test( NAME         4denvar
-                  EXE          fv3jedi_var.x
-                  MPI          18
-                  TEST_DEPENDS bumpparameters_nicas_gfs )
+if (NOT SKIP_LARGE_TESTS)
+  fv3jedi_add_test( NAME         4denvar
+                    EXE          fv3jedi_var.x
+                    MPI          18
+                    TEST_DEPENDS bumpparameters_nicas_gfs )
+endif()
 
 # Hybrid 4DVar
 # ------------
@@ -1051,11 +1053,13 @@ fv3jedi_add_test( NAME         addincrement_gfs
                   TOL          1.0e-3 0
                   TEST_DEPENDS diffstates_gfs )
 
-fv3jedi_add_test( NAME         addincrement_geos
-                  EXE          fv3jedi_addincrement.x
-                  MPI          12
-                  TOL          1.0e-4 0
-                  TEST_DEPENDS diffstates_geos )
+if (NOT SKIP_LARGE_TESTS)
+  fv3jedi_add_test( NAME         addincrement_geos
+                    EXE          fv3jedi_addincrement.x
+                    MPI          12
+                    TOL          1.0e-4 0
+                    TEST_DEPENDS diffstates_geos )
+endif()
 
 # LETKF / LGETKF
 # --------------


### PR DESCRIPTION
## Description

Turn off 4DEnVar and add increment tests that run on >6 procs. Make skipping these and all large tests `on` by default