### PR TITLE
Add fraction_of_land field to read in orog file

### DIFF
--- a/src/fv3jedi/IO/FV3Restart/fv3jedi_io_fms_mod.f90
+++ b/src/fv3jedi/IO/FV3Restart/fv3jedi_io_fms_mod.f90
@@ -572,6 +572,7 @@ if (trim(io_file) == 'default') then
 
   ! Orog variables if short name contains orog
   if (index(trim(field%short_name), 'orog') /= 0) io_file = 'orography'
+  if (index(trim(field%short_name), 'fraction_of_land') /= 0) io_file = 'orography'
 
   ! Cold start variables if short name contains cold
   if (index(trim(field%short_name), 'cold') /= 0) io_file = 'cold'


### PR DESCRIPTION
## Description

In order to solve the issue outlined in https://github.com/NOAA-EMC/GFS/issues/8, `fraction_of_land` field (when present) needs to be read from orog file.

## Issue(s) addressed

Resolves https://github.com/NOAA-EMC/GFS/issues/8

## Dependencies

List the other PRs that this PR is dependent on:
The edits made in the PR can be standalone. But to solve the issue and realize the function needed, this PR is required to be merged in line with another jcb-gdas PR: https://github.com/NOAA-EMC/jcb-gdas/pull/146

## Impact

N/A

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
