### PR TITLE
Add missing soil moisture and temperature fields to default field metadata

### DIFF
--- a/src/fv3jedi/FieldMetadata/FieldsMetadataDefault.h
+++ b/src/fv3jedi/FieldMetadata/FieldsMetadataDefault.h
@@ -475,7 +475,71 @@ namespace fv3jedi {
     md.space = "magnitude";
     addFieldMetadata(fieldsmetadata, nlev, md);
 
-    md.longName = "soilt";
+/*    md.longName = "soilt";
+    md.units = "none";
+    md.kind = "double";
+    md.tracer = "false";
+    md.levels = "1";
+    md.space = "magnitude";
+    addFieldMetadata(fieldsmetadata, nlev, md);
+*/
+    md.longName = "soilt1";
+    md.units = "none";
+    md.kind = "double";
+    md.tracer = "false";
+    md.levels = "1";
+    md.space = "magnitude";
+    addFieldMetadata(fieldsmetadata, nlev, md);
+
+    md.longName = "soilt2";
+    md.units = "none";
+    md.kind = "double";
+    md.tracer = "false";
+    md.levels = "1";
+    md.space = "magnitude";
+    addFieldMetadata(fieldsmetadata, nlev, md);
+
+    md.longName = "soilt3";
+    md.units = "none";
+    md.kind = "double";
+    md.tracer = "false";
+    md.levels = "1";
+    md.space = "magnitude";
+    addFieldMetadata(fieldsmetadata, nlev, md);
+
+    md.longName = "soilt4";
+    md.units = "none";
+    md.kind = "double";
+    md.tracer = "false";
+    md.levels = "1";
+    md.space = "magnitude";
+    addFieldMetadata(fieldsmetadata, nlev, md);
+
+    md.longName = "soill1";
+    md.units = "none";
+    md.kind = "double";
+    md.tracer = "false";
+    md.levels = "1";
+    md.space = "magnitude";
+    addFieldMetadata(fieldsmetadata, nlev, md);
+
+    md.longName = "soill2";
+    md.units = "none";
+    md.kind = "double";
+    md.tracer = "false";
+    md.levels = "1";
+    md.space = "magnitude";
+    addFieldMetadata(fieldsmetadata, nlev, md);
+
+    md.longName = "soill3";
+    md.units = "none";
+    md.kind = "double";
+    md.tracer = "false";
+    md.levels = "1";
+    md.space = "magnitude";
+    addFieldMetadata(fieldsmetadata, nlev, md);
+
+    md.longName = "soil14";
     md.units = "none";
     md.kind = "double";
     md.tracer = "false";
@@ -733,6 +797,14 @@ namespace fv3jedi {
 
     md.longName = "air_temperature_at_2m";
     md.units = "K";
+    md.kind = "double";
+    md.tracer = "false";
+    md.levels = "1";
+    md.space = "magnitude";
+    addFieldMetadata(fieldsmetadata, nlev, md);
+
+    md.longName = "specfic_humidity_at_2m";
+    md.units = "kg/kg";
     md.kind = "double";
     md.tracer = "false";
     md.levels = "1";

--- a/src/fv3jedi/FieldMetadata/FieldsMetadataDefault.h
+++ b/src/fv3jedi/FieldMetadata/FieldsMetadataDefault.h
@@ -563,14 +563,6 @@ namespace fv3jedi {
     md.space = "magnitude";
     addFieldMetadata(fieldsmetadata, nlev, md);
 
-    md.longName = "slc";        //soilLiquidContentVolumetric?
-    md.units = "none";
-    md.kind = "double";
-    md.tracer = "false";
-    md.levels = "4";
-    md.space = "magnitude";
-    addFieldMetadata(fieldsmetadata, nlev, md);
-
     md.longName = "smois";
     md.units = "none";
     md.kind = "double";

--- a/src/fv3jedi/FieldMetadata/FieldsMetadataDefault.h
+++ b/src/fv3jedi/FieldMetadata/FieldsMetadataDefault.h
@@ -483,7 +483,7 @@ namespace fv3jedi {
     md.space = "magnitude";
     addFieldMetadata(fieldsmetadata, nlev, md);
 
-    md.longName = "soilt1";
+    md.longName = "soilt";
     md.units = "none";
     md.kind = "double";
     md.tracer = "false";
@@ -491,6 +491,14 @@ namespace fv3jedi {
     md.space = "magnitude";
     addFieldMetadata(fieldsmetadata, nlev, md);
 
+    md.longName = "soilt1";
+    md.units = "none";
+    md.kind = "double";
+    md.tracer = "false";
+    md.levels = "1";
+    md.space = "magnitude";
+    addFieldMetadata(fieldsmetadata, nlev, md);
+    
     md.longName = "soilt2";
     md.units = "none";
     md.kind = "double";

--- a/src/fv3jedi/FieldMetadata/FieldsMetadataDefault.h
+++ b/src/fv3jedi/FieldMetadata/FieldsMetadataDefault.h
@@ -483,14 +483,6 @@ namespace fv3jedi {
     md.space = "magnitude";
     addFieldMetadata(fieldsmetadata, nlev, md);
 
-/*    md.longName = "soilt";
-    md.units = "none";
-    md.kind = "double";
-    md.tracer = "false";
-    md.levels = "1";
-    md.space = "magnitude";
-    addFieldMetadata(fieldsmetadata, nlev, md);
-*/
     md.longName = "soilt1";
     md.units = "none";
     md.kind = "double";
@@ -556,6 +548,14 @@ namespace fv3jedi {
     addFieldMetadata(fieldsmetadata, nlev, md);
 
     md.longName = "soilMoistureVolumetric";
+    md.units = "none";
+    md.kind = "double";
+    md.tracer = "false";
+    md.levels = "4";
+    md.space = "magnitude";
+    addFieldMetadata(fieldsmetadata, nlev, md);
+
+    md.longName = "slc";        //soilLiquidContentVolumetric?
     md.units = "none";
     md.kind = "double";
     md.tracer = "false";

--- a/src/fv3jedi/IO/FV3Restart/fv3jedi_io_fms2_mod.f90
+++ b/src/fv3jedi/IO/FV3Restart/fv3jedi_io_fms2_mod.f90
@@ -947,7 +947,6 @@ if (index(trim(field%long_name), 'cold') /= 0) io_file = 'cold'
 
 ! Multi-level soils go in surface
 if (trim(field%long_name) == 'stc') io_file = 'surface'
-if (trim(field%long_name) == 'slc') io_file = 'surface'
 if (trim(field%long_name) == 'soilMoistureVolumetric') io_file = 'surface'
 if (trim(field%long_name) == 'tslb') io_file = 'surface'
 if (trim(field%long_name) == 'smois') io_file = 'surface'

--- a/src/fv3jedi/IO/FV3Restart/fv3jedi_io_fms2_mod.f90
+++ b/src/fv3jedi/IO/FV3Restart/fv3jedi_io_fms2_mod.f90
@@ -947,6 +947,7 @@ if (index(trim(field%long_name), 'cold') /= 0) io_file = 'cold'
 
 ! Multi-level soils go in surface
 if (trim(field%long_name) == 'stc') io_file = 'surface'
+if (trim(field%long_name) == 'slc') io_file = 'surface'
 if (trim(field%long_name) == 'soilMoistureVolumetric') io_file = 'surface'
 if (trim(field%long_name) == 'tslb') io_file = 'surface'
 if (trim(field%long_name) == 'smois') io_file = 'surface'


### PR DESCRIPTION
## Description

The default metadata in FV3-JEDI doesn't include the soil layer variables such as soill1, soilt1... which are required for land/sfc soil moisture DA with observations from satellite products such as SMAP and near surface station temperature and humidity observations.  This PR adds these variables.

## Issue(s) addressed

Resolves #<issue_number>

## Dependencies

List the other PRs that this PR is dependent on:
None

Companion PR in GDASApp: https://github.com/NOAA-EMC/GDASApp/pull/2180

## Impact

Expected impact on downstream repositories:

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
